### PR TITLE
Improve modal sizing and safe-area padding in CSS

### DIFF
--- a/styles/main.css
+++ b/styles/main.css
@@ -876,6 +876,8 @@ body.component-selecting {
     overflow: auto;
     align-items: center;
     justify-content: center;
+    padding: max(12px, env(safe-area-inset-top, 0px)) 12px max(12px, env(safe-area-inset-bottom, 0px));
+    box-sizing: border-box;
 
     background: rgba(6, 6, 8, 0.35);
 }
@@ -886,7 +888,7 @@ body.component-selecting {
     margin: 0 auto;
     width: min(92vw, 620px);
     height: auto;
-    max-height: min(calc(100vh - max(24px, 8vh)), 500px);
+    max-height: min(90%, 500px);
     padding: 12px;
     transform: none;
     display: flex;
@@ -1071,11 +1073,11 @@ body.component-selecting {
 }
 
 #settingsModal .modalDialog {
-    max-height: min(72vh, 440px);
+    max-height: min(88%, 440px);
 }
 
 .editValueModalDialog {
-    max-height: min(58vh, 300px);
+    max-height: min(82%, 300px);
 }
 
 .editValueLabel {


### PR DESCRIPTION
### Motivation

- Make modal dialogs behave better on mobile and varying viewport sizes by avoiding brittle `vh` calculations and respecting device safe areas.
- Reduce layout issues where modals could overflow or be clipped by system UI by using percentage-based limits and proper box-sizing.

### Description

- Added safe-area aware padding to `.modal` with `padding: max(12px, env(safe-area-inset-top, 0px)) ...` and set `box-sizing: border-box` on `.modal` to ensure consistent inner spacing. 
- Simplified and replaced complex `vh`-based `max-height` for `.modalDialog` with `max-height: min(90%, 500px)` to constrain dialogs by viewport percentage and a fixed cap. 
- Adjusted modal-specific max-heights from `vh` values to percentage-based limits for `#settingsModal .modalDialog` (`min(88%, 440px)`) and `.editValueModalDialog` (`min(82%, 300px)`).

### Testing

- Ran the stylesheet build and linter with `npm run build` and `npm run lint`, both completed successfully. 
- Ran automated UI snapshots/visual tests in CI and they passed with no regressions detected.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d50f261798832ea54d8036f82071f0)